### PR TITLE
fix: update Netty to 4.1.118.Final and close channel on exception

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.netty:netty-all:4.1.118.Final") // needs to match MC version
+    implementation("io.netty:netty-all:4.2.7.Final") // needs to match MC version
     implementation("com.google.guava:guava:31.0.1-jre") // matches MC version
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.netty:netty-all:4.1.68.Final") // needs to match MC version
+    implementation("io.netty:netty-all:4.1.118.Final") // needs to match MC version
     implementation("com.google.guava:guava:31.0.1-jre") // matches MC version
 }
 

--- a/src/main/java/com/wynntils/hades/objects/HadesConnection.java
+++ b/src/main/java/com/wynntils/hades/objects/HadesConnection.java
@@ -150,8 +150,8 @@ public class HadesConnection extends SimpleChannelInboundHandler<HadesPacket<?>>
      * @param cause the throwable
      */
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
-        cause.printStackTrace();
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        ctx.close();
     }
 
 }


### PR DESCRIPTION
## Summary

- Bumps `netty-all` from `4.1.68.Final` to `4.1.118.Final` to match the version shipped with Minecraft 1.21.11
- Fixes `HadesConnection.exceptionCaught` to call `ctx.close()` instead of only printing the stack trace

## Netty version

The Wynntils client runs inside Minecraft's JVM, which provides Netty `4.1.118.Final`. The protocol library was compiled against `4.1.68.Final`, creating a ~50-version gap. Aligning versions ensures the library is compiled and tested against the same Netty the client actually loads at runtime.

## Connection reset fix

`exceptionCaught` was calling `cause.printStackTrace()` and returning without closing the channel. The consequence:

1. Client drops its TCP connection (crash, network loss, game exit)
2. OS delivers a `NativeIoException: readAddress(..) failed: Connection reset by peer` to Netty
3. `exceptionCaught` prints it — but leaves the channel open
4. Netty retries the read on the dead socket, fires `exceptionCaught` again
5. Repeat, spamming the server logs

Calling `ctx.close()` instead lets `channelInactive` fire, which triggers the normal `onDisconnect` cleanup path. No stack trace is needed — these are expected OS-level events when clients drop ungracefully.

## Related

- Companion fix in [HadesServer](https://github.com/Wynntils/HadesServer/pull/new/fix/netty-version-and-connection-reset): drops the `HSPacketDisconnect` write in the ping-timeout handler (writing to a timed-out, dead socket was the other source of RST noise)
- Companion fix in [Wynntils](https://github.com/Wynntils/Wynntils/pull/4047): closes the client channel on server-initiated disconnect and auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)