### PR TITLE
feat: add VERSION_0_6_2 and HCPacketGearUpdate

### DIFF
--- a/src/main/java/com/wynntils/hades/protocol/enums/HadesVersion.java
+++ b/src/main/java/com/wynntils/hades/protocol/enums/HadesVersion.java
@@ -2,5 +2,6 @@ package com.wynntils.hades.protocol.enums;
 
 public enum HadesVersion {
     UNKNOWN,
-    VERSION_0_6_1 // Gear sharing support with the introduction of versioning
+    VERSION_0_6_1, // Gear sharing support with the introduction of versioning
+    VERSION_0_6_2  // Gear updates decoupled from position/vitals via HCPacketGearUpdate
 }

--- a/src/main/java/com/wynntils/hades/protocol/interfaces/adapters/IHadesServerAdapter.java
+++ b/src/main/java/com/wynntils/hades/protocol/interfaces/adapters/IHadesServerAdapter.java
@@ -65,4 +65,13 @@ public interface IHadesServerAdapter extends IHadesAdapter {
      * @param packet the packet itself
      */
     void handlePing(HCPacketPing packet);
+
+    /**
+     * Used to update the player's gear independently of position/vitals.
+     * Sent on gear change and once on initial login/world load.
+     * @see HCPacketGearUpdate
+     *
+     * @param packet the packet itself
+     */
+    void handleGearUpdate(HCPacketGearUpdate packet);
 }

--- a/src/main/java/com/wynntils/hades/protocol/packets/PacketRegistry.java
+++ b/src/main/java/com/wynntils/hades/protocol/packets/PacketRegistry.java
@@ -34,6 +34,7 @@ public enum PacketRegistry {
             registerPacket(HCPacketDiscordLobbyClient.class);
             registerPacket(HCPacketUpdateWorld.class);
             registerPacket(HCPacketPing.class);
+            registerPacket(HCPacketGearUpdate.class);
         }
     };
 

--- a/src/main/java/com/wynntils/hades/protocol/packets/client/HCPacketGearUpdate.java
+++ b/src/main/java/com/wynntils/hades/protocol/packets/client/HCPacketGearUpdate.java
@@ -12,7 +12,17 @@ public class HCPacketGearUpdate implements HadesPacket<IHadesServerAdapter> {
 
     String helmet, chestplate, leggings, boots, ringOne, ringTwo, bracelet, necklace, heldItem;
 
-    public HCPacketGearUpdate() { }
+    public HCPacketGearUpdate() {
+        this.helmet = "";
+        this.chestplate = "";
+        this.leggings = "";
+        this.boots = "";
+        this.ringOne = "";
+        this.ringTwo = "";
+        this.bracelet = "";
+        this.necklace = "";
+        this.heldItem = "";
+    }
 
     public HCPacketGearUpdate(String helmet, String chestplate, String leggings, String boots,
                               String ringOne, String ringTwo, String bracelet, String necklace,

--- a/src/main/java/com/wynntils/hades/protocol/packets/client/HCPacketGearUpdate.java
+++ b/src/main/java/com/wynntils/hades/protocol/packets/client/HCPacketGearUpdate.java
@@ -1,0 +1,71 @@
+package com.wynntils.hades.protocol.packets.client;
+
+import com.wynntils.hades.protocol.interfaces.HadesPacket;
+import com.wynntils.hades.protocol.interfaces.adapters.IHadesServerAdapter;
+import com.wynntils.hades.utils.HadesBuffer;
+
+/**
+ * Sent by the client when gear changes, and once on initial login/world load.
+ * Decoupled from HCPacketUpdateStatus so gear is not retransmitted on every position tick.
+ */
+public class HCPacketGearUpdate implements HadesPacket<IHadesServerAdapter> {
+
+    String helmet, chestplate, leggings, boots, ringOne, ringTwo, bracelet, necklace, heldItem;
+
+    public HCPacketGearUpdate() { }
+
+    public HCPacketGearUpdate(String helmet, String chestplate, String leggings, String boots,
+                              String ringOne, String ringTwo, String bracelet, String necklace,
+                              String heldItem) {
+        this.helmet = helmet;
+        this.chestplate = chestplate;
+        this.leggings = leggings;
+        this.boots = boots;
+        this.ringOne = ringOne;
+        this.ringTwo = ringTwo;
+        this.bracelet = bracelet;
+        this.necklace = necklace;
+        this.heldItem = heldItem;
+    }
+
+    public String getHelmet() { return helmet; }
+    public String getChestplate() { return chestplate; }
+    public String getLeggings() { return leggings; }
+    public String getBoots() { return boots; }
+    public String getRingOne() { return ringOne; }
+    public String getRingTwo() { return ringTwo; }
+    public String getBracelet() { return bracelet; }
+    public String getNecklace() { return necklace; }
+    public String getHeldItem() { return heldItem; }
+
+    @Override
+    public void readData(HadesBuffer buffer) {
+        helmet = buffer.readString();
+        chestplate = buffer.readString();
+        leggings = buffer.readString();
+        boots = buffer.readString();
+        ringOne = buffer.readString();
+        ringTwo = buffer.readString();
+        bracelet = buffer.readString();
+        necklace = buffer.readString();
+        heldItem = buffer.readString();
+    }
+
+    @Override
+    public void writeData(HadesBuffer buffer) {
+        buffer.writeString(helmet);
+        buffer.writeString(chestplate);
+        buffer.writeString(leggings);
+        buffer.writeString(boots);
+        buffer.writeString(ringOne);
+        buffer.writeString(ringTwo);
+        buffer.writeString(bracelet);
+        buffer.writeString(necklace);
+        buffer.writeString(heldItem);
+    }
+
+    @Override
+    public void process(IHadesServerAdapter handler) {
+        handler.handleGearUpdate(this);
+    }
+}

--- a/src/main/java/com/wynntils/hades/protocol/packets/server/HSPacketUpdateMutual.java
+++ b/src/main/java/com/wynntils/hades/protocol/packets/server/HSPacketUpdateMutual.java
@@ -156,6 +156,12 @@ public class HSPacketUpdateMutual implements HadesPacket<IHadesClientAdapter> {
         return heldItem;
     }
 
+    /**
+     * Returns true if gear data was present in the wire buffer.
+     * Note: returns false both when the sender omitted gear AND when all nine
+     * gear strings are empty — these cases are indistinguishable on the wire.
+     * Receivers must treat hasGear() == false as "do not update gear display".
+     */
     public boolean hasGear() {
         return hasGear;
     }

--- a/src/main/java/com/wynntils/hades/protocol/packets/server/HSPacketUpdateMutual.java
+++ b/src/main/java/com/wynntils/hades/protocol/packets/server/HSPacketUpdateMutual.java
@@ -20,6 +20,7 @@ public class HSPacketUpdateMutual implements HadesPacket<IHadesClientAdapter> {
     boolean isMutualFriend;
     boolean isGuildMember;
     String helmet, chestplate, leggings, boots, ringOne, ringTwo, bracelet, necklace, heldItem;
+    private boolean hasGear = false;
 
     public HSPacketUpdateMutual() { }
 
@@ -155,6 +156,10 @@ public class HSPacketUpdateMutual implements HadesPacket<IHadesClientAdapter> {
         return heldItem;
     }
 
+    public boolean hasGear() {
+        return hasGear;
+    }
+
     @Override
     public void readData(HadesBuffer buffer) {
         user = buffer.readUUID();
@@ -171,6 +176,7 @@ public class HSPacketUpdateMutual implements HadesPacket<IHadesClientAdapter> {
         isGuildMember = buffer.readBoolean();
 
         if (buffer.readableBytes() > 0) {
+            hasGear = true;
             helmet = buffer.readString();
             chestplate = buffer.readString();
             leggings = buffer.readString();
@@ -181,6 +187,7 @@ public class HSPacketUpdateMutual implements HadesPacket<IHadesClientAdapter> {
             necklace = buffer.readString();
             heldItem = buffer.readString();
         } else {
+            hasGear = false;
             helmet = "";
             chestplate = "";
             leggings = "";


### PR DESCRIPTION
Adds protocol support for decoupling gear from position/vitals updates.

- New `VERSION_0_6_2` enum value
- New `HCPacketGearUpdate` client→server packet (9 gear slot strings)
- `handleGearUpdate` added to `IHadesServerAdapter`
- `HSPacketUpdateMutual` gains `hasGear()` flag so receivers can distinguish "gear not present in this packet" from "player has no gear"

Depends on HadesServer and Wynntils PRs to complete the feature.